### PR TITLE
Use `find_dependency` in CMake config

### DIFF
--- a/config.cmake.in
+++ b/config.cmake.in
@@ -1,13 +1,15 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+
 # GCC does not allow the use of std::promise, std::future
 # without compiling with pthreads support.
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
   set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-  find_package(Threads REQUIRED)
+  find_dependency(Threads)
 endif()
 
-find_package(CURL REQUIRED)
+find_dependency(CURL)
 include("${CMAKE_CURRENT_LIST_DIR}/sourcemeta_hydra_http.cmake")
 check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
