### PR TITLE
Set HTTP client headers right before issuing the request

### DIFF
--- a/src/httpclient/stream_curl.cc
+++ b/src/httpclient/stream_curl.cc
@@ -278,8 +278,6 @@ auto ClientStream::send() -> std::future<Status> {
 
   handle_curl(curl_easy_setopt(this->internal->handle, CURLOPT_URL,
                                this->internal->url.c_str()));
-  handle_curl(curl_easy_setopt(this->internal->handle, CURLOPT_HTTPHEADER,
-                               this->internal->headers));
 
   // Accept all supported compression mechanisms
   // See https://curl.se/libcurl/c/CURLOPT_ACCEPT_ENCODING.html
@@ -301,6 +299,8 @@ auto ClientStream::send() -> std::future<Status> {
                                callback_on_header));
   handle_curl(
       curl_easy_setopt(this->internal->handle, CURLOPT_HEADERDATA, this));
+  handle_curl(curl_easy_setopt(this->internal->handle, CURLOPT_HTTPHEADER,
+                               this->internal->headers));
 
   // Perform request
   handle_curl(curl_easy_perform(this->internal->handle));


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
