### PR TITLE
Implement an `unsigned long` overload to `header()`

### DIFF
--- a/src/httpclient/include/sourcemeta/hydra/httpclient_request.h
+++ b/src/httpclient/include/sourcemeta/hydra/httpclient_request.h
@@ -143,6 +143,21 @@ public:
   /// ```
   auto header(std::string_view key, int value) -> void;
 
+  /// Set an HTTP request header whose value is an unsigned long integer. For
+  /// example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/hydra/httpclient.h>
+  /// #include <cassert>
+  ///
+  /// sourcemeta::hydra::http::ClientRequest request{"https://www.example.com"};
+  /// const unsigned long value = 3;
+  /// request.header("X-Favourite-Number", value);
+  /// sourcemeta::hydra::http::ClientResponse response{request.send().get()};
+  /// assert(response.status() == sourcemeta::hydra::http::Status::OK);
+  /// ```
+  auto header(std::string_view key, unsigned long value) -> void;
+
   /// Retrieve the URL that the request will be sent to. For example:
   ///
   /// ```cpp

--- a/src/httpclient/include/sourcemeta/hydra/httpclient_stream.h
+++ b/src/httpclient/include/sourcemeta/hydra/httpclient_stream.h
@@ -173,6 +173,30 @@ public:
   /// ```
   auto header(std::string_view key, int value) -> void;
 
+  /// Set an HTTP request header whose value is an unsigned long. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/hydra/httpclient.h>
+  /// #include <iostream>
+  ///
+  /// sourcemeta::hydra::http::ClientStream request{"https://www.example.com"};
+  /// const unsigned long value = 3;
+  /// request.header("X-Favourite-Number", value);
+  ///
+  /// request.on_data([](const sourcemeta::hydra::http::Status status,
+  ///                    std::span<const std::uint8_t> buffer) noexcept {
+  ///   std::cerr << "Code: " << status << "\n";
+  ///
+  ///   // Copy to standard output
+  ///   for (const auto byte : buffer) {
+  ///     std::cout << static_cast<char>(byte);
+  ///   }
+  /// });
+  ///
+  /// request.send().wait();
+  /// ```
+  auto header(std::string_view key, unsigned long value) -> void;
+
   /// Retrieve the URL that the request will be sent to. For example:
   ///
   /// ```cpp

--- a/src/httpclient/request.cc
+++ b/src/httpclient/request.cc
@@ -49,6 +49,10 @@ auto ClientRequest::header(std::string_view key, int value) -> void {
   this->stream.header(key, value);
 }
 
+auto ClientRequest::header(std::string_view key, unsigned long value) -> void {
+  this->stream.header(key, value);
+}
+
 auto ClientRequest::url() const -> std::string_view {
   return this->stream.url();
 }

--- a/src/httpclient/stream_curl.cc
+++ b/src/httpclient/stream_curl.cc
@@ -253,6 +253,10 @@ auto ClientStream::header(std::string_view key, int value) -> void {
   this->header(key, std::to_string(value));
 }
 
+auto ClientStream::header(std::string_view key, unsigned long value) -> void {
+  this->header(key, std::to_string(value));
+}
+
 auto ClientStream::url() const -> std::string_view {
   return this->internal->url;
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
