### PR TITLE
Pull the same ClangFormat version in every platform using `pip`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,14 @@ jobs:
       CXX: ${{ matrix.platform.cxx }}
       TEST_PORT: 9999
     steps:
+      - name: Install ClangFormat
+        run: pip install clang-format==18.1.0
+
       - name: Install dependencies (GNU/Linux)
         if: runner.os == 'linux'
         run: |
           sudo apt-get update --yes
-          sudo apt-get install --yes clang-format libcurl4-openssl-dev nodejs
+          sudo apt-get install --yes libcurl4-openssl-dev nodejs
 
       # See https://github.com/actions/runner-images/issues/8659
       - name: Workaround Clang issue (GNU/Linux)

--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,3 @@
 brew "cmake"
-brew "clang-format"
 brew "doxygen"
 brew "node"

--- a/src/bucket/include/sourcemeta/hydra/bucket_aws_sigv4.h
+++ b/src/bucket/include/sourcemeta/hydra/bucket_aws_sigv4.h
@@ -29,43 +29,39 @@ aws_sigv4(const http::Method method, const sourcemeta::jsontoolkit::URI &url,
           const std::chrono::system_clock::time_point now)
     -> std::map<std::string, std::string>;
 
-auto SOURCEMETA_HYDRA_BUCKET_EXPORT aws_sigv4_scope(std::string_view datastamp,
-                                                    std::string_view region,
-                                                    std::ostream &output)
-    -> void;
+auto SOURCEMETA_HYDRA_BUCKET_EXPORT
+aws_sigv4_scope(std::string_view datastamp, std::string_view region,
+                std::ostream &output) -> void;
 
-auto SOURCEMETA_HYDRA_BUCKET_EXPORT aws_sigv4_key(std::string_view secret_key,
-                                                  std::string_view region,
-                                                  std::string_view datastamp)
-    -> std::string;
+auto SOURCEMETA_HYDRA_BUCKET_EXPORT
+aws_sigv4_key(std::string_view secret_key, std::string_view region,
+              std::string_view datastamp) -> std::string;
 
 auto SOURCEMETA_HYDRA_BUCKET_EXPORT
 aws_sigv4_canonical(const http::Method method, std::string_view host,
                     std::string_view path, std::string_view content_checksum,
                     std::string_view timestamp) -> std::string;
 
-auto SOURCEMETA_HYDRA_BUCKET_EXPORT aws_sigv4_sha256(std::string_view input,
-                                                     std::ostream &output)
-    -> void;
-auto SOURCEMETA_HYDRA_BUCKET_EXPORT aws_sigv4_hmac_sha256(
-    std::string_view secret, std::string_view value, std::ostream &output)
-    -> void;
-auto SOURCEMETA_HYDRA_BUCKET_EXPORT aws_sigv4_base64(std::string_view input,
-                                                     std::ostream &output)
-    -> void;
+auto SOURCEMETA_HYDRA_BUCKET_EXPORT
+aws_sigv4_sha256(std::string_view input, std::ostream &output) -> void;
+auto SOURCEMETA_HYDRA_BUCKET_EXPORT
+aws_sigv4_hmac_sha256(std::string_view secret, std::string_view value,
+                      std::ostream &output) -> void;
+auto SOURCEMETA_HYDRA_BUCKET_EXPORT
+aws_sigv4_base64(std::string_view input, std::ostream &output) -> void;
 
 // A datestamp format is as follows:
 // YYYY: Four-digit year
 // MM: Two-digit month (01-12)
 // DD: Two-digit day (01-31)
 // Example: 20230913 (September 13, 2023)
-auto SOURCEMETA_HYDRA_BUCKET_EXPORT aws_sigv4_datastamp(
-    const std::chrono::system_clock::time_point time, std::ostream &output)
-    -> void;
+auto SOURCEMETA_HYDRA_BUCKET_EXPORT
+aws_sigv4_datastamp(const std::chrono::system_clock::time_point time,
+                    std::ostream &output) -> void;
 
-auto SOURCEMETA_HYDRA_BUCKET_EXPORT aws_sigv4_iso8601(
-    const std::chrono::system_clock::time_point time, std::ostream &output)
-    -> void;
+auto SOURCEMETA_HYDRA_BUCKET_EXPORT
+aws_sigv4_iso8601(const std::chrono::system_clock::time_point time,
+                  std::ostream &output) -> void;
 
 } // namespace sourcemeta::hydra
 

--- a/src/http/include/sourcemeta/hydra/http_method.h
+++ b/src/http/include/sourcemeta/hydra/http_method.h
@@ -38,9 +38,8 @@ enum class Method {
 /// output << sourcemeta::hydra::http::Method::GET;
 /// assert(output.str() == "GET");
 /// ```
-auto SOURCEMETA_HYDRA_HTTP_EXPORT operator<<(std::ostream &stream,
-                                             const Method method)
-    -> std::ostream &;
+auto SOURCEMETA_HYDRA_HTTP_EXPORT
+operator<<(std::ostream &stream, const Method method) -> std::ostream &;
 
 /// @ingroup http
 /// Construct a HTTP method from a string. Note that casing is not supported.

--- a/src/http/include/sourcemeta/hydra/http_status.h
+++ b/src/http/include/sourcemeta/hydra/http_status.h
@@ -89,9 +89,8 @@ enum class Status : std::uint16_t {
 };
 
 /// @ingroup http
-auto SOURCEMETA_HYDRA_HTTP_EXPORT operator<<(std::ostream &stream,
-                                             const Status value)
-    -> std::ostream &;
+auto SOURCEMETA_HYDRA_HTTP_EXPORT
+operator<<(std::ostream &stream, const Status value) -> std::ostream &;
 
 } // namespace sourcemeta::hydra::http
 

--- a/src/httpclient/request.cc
+++ b/src/httpclient/request.cc
@@ -40,8 +40,8 @@ auto ClientRequest::capture(std::initializer_list<std::string> headers)
 
 auto ClientRequest::capture() -> void { this->capture_all_ = true; }
 
-auto ClientRequest::header(std::string_view key, std::string_view value)
-    -> void {
+auto ClientRequest::header(std::string_view key,
+                           std::string_view value) -> void {
   this->stream.header(key, value);
 }
 

--- a/src/httpclient/stream_curl.cc
+++ b/src/httpclient/stream_curl.cc
@@ -42,10 +42,10 @@ inline auto handle_curl(CURLcode code) -> void {
   }
 }
 
-auto callback_on_response_body(
-    const void *const data, const std::size_t size, const std::size_t count,
-    const sourcemeta::hydra::http::ClientStream *const request) noexcept
-    -> std::size_t {
+auto callback_on_response_body(const void *const data, const std::size_t size,
+                               const std::size_t count,
+                               const sourcemeta::hydra::http::ClientStream
+                                   *const request) noexcept -> std::size_t {
   const std::size_t total_size{size * count};
   if (request->internal->on_data) {
     try {
@@ -61,10 +61,10 @@ auto callback_on_response_body(
   return total_size;
 }
 
-auto callback_on_header(
-    const void *const data, const std::size_t size, const std::size_t count,
-    sourcemeta::hydra::http::ClientStream *const request) noexcept
-    -> std::size_t {
+auto callback_on_header(const void *const data, const std::size_t size,
+                        const std::size_t count,
+                        sourcemeta::hydra::http::ClientStream
+                            *const request) noexcept -> std::size_t {
   const std::size_t total_size{size * count};
   const std::string_view line{static_cast<const char *>(data), total_size};
   const std::size_t colon{line.find(':')};
@@ -128,10 +128,10 @@ auto callback_on_header(
   return total_size;
 }
 
-auto callback_on_request_body(
-    char *buffer, const std::size_t size, const std::size_t count,
-    sourcemeta::hydra::http::ClientStream *const request) noexcept
-    -> std::size_t {
+auto callback_on_request_body(char *buffer, const std::size_t size,
+                              const std::size_t count,
+                              sourcemeta::hydra::http::ClientStream
+                                  *const request) noexcept -> std::size_t {
   assert(buffer);
   assert(request->internal->on_body);
   const std::size_t total_size{size * count};
@@ -240,8 +240,8 @@ auto ClientStream::on_body(BodyCallback callback) noexcept -> void {
   this->internal->on_body = std::move(callback);
 }
 
-auto ClientStream::header(std::string_view key, std::string_view value)
-    -> void {
+auto ClientStream::header(std::string_view key,
+                          std::string_view value) -> void {
   std::stringstream stream;
   stream << key << ": " << value;
   const std::string result{stream.str()};

--- a/test/httpclient/request_1_1_test.cc
+++ b/test/httpclient/request_1_1_test.cc
@@ -13,8 +13,8 @@
 
 #include "http_base_url.h"
 
-static auto body(sourcemeta::hydra::http::ClientResponse &response)
-    -> std::string {
+static auto
+body(sourcemeta::hydra::http::ClientResponse &response) -> std::string {
   std::ostringstream result;
   std::copy(
       std::istreambuf_iterator<std::ostringstream::char_type>(response.body()),


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
