### PR TITLE
Support `X-Request-Id` in the HTTP server by default

### DIFF
--- a/src/httpserver/httpserver.cc
+++ b/src/httpserver/httpserver.cc
@@ -35,6 +35,9 @@ static auto wrap_route(
   sourcemeta::hydra::http::ServerResponse response{response_handler};
   const sourcemeta::hydra::http::ServerRequest request{request_handler};
 
+  // For easy tracking
+  response.header("X-Request-Id", logger.id());
+
   try {
     callback(logger, request, response);
   } catch (...) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
