### PR TITLE
Enable `/MP` on MSVC for faster builds

### DIFF
--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -6,6 +6,7 @@ function(sourcemeta_hydra_add_compile_options target)
       /permissive-
       /W4
       /WL
+      /MP
       /sdl)
   else()
     target_compile_options("${target}" PRIVATE


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
