### PR TITLE
Don't directly link `src/bucket` to BearSSL anymore

### DIFF
--- a/src/bucket/CMakeLists.txt
+++ b/src/bucket/CMakeLists.txt
@@ -12,4 +12,3 @@ target_link_libraries(sourcemeta_hydra_bucket PUBLIC sourcemeta::jsontoolkit::ur
 target_link_libraries(sourcemeta_hydra_bucket PRIVATE sourcemeta::hydra::crypto)
 target_link_libraries(sourcemeta_hydra_bucket PUBLIC sourcemeta::hydra::http)
 target_link_libraries(sourcemeta_hydra_bucket PRIVATE sourcemeta::hydra::httpclient)
-target_link_libraries(sourcemeta_hydra_bucket PRIVATE BearSSL::BearSSL)


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
