### PR TITLE
Extend `serve_file` to take a custom HTTP status code

### DIFF
--- a/src/httpserver/include/sourcemeta/hydra/httpserver.h
+++ b/src/httpserver/include/sourcemeta/hydra/httpserver.h
@@ -226,7 +226,7 @@ private:
 /// ```
 auto SOURCEMETA_HYDRA_HTTPSERVER_EXPORT
 serve_file(const std::filesystem::path &file_path, const ServerRequest &request,
-           ServerResponse &response) -> void;
+           ServerResponse &response, const Status code = Status::OK) -> void;
 
 } // namespace sourcemeta::hydra::http
 

--- a/src/httpserver/static.cc
+++ b/src/httpserver/static.cc
@@ -9,8 +9,8 @@
 namespace sourcemeta::hydra::http {
 
 auto serve_file(const std::filesystem::path &file_path,
-                const ServerRequest &request, ServerResponse &response)
-    -> void {
+                const ServerRequest &request, ServerResponse &response,
+                const Status code) -> void {
   assert(request.method() == sourcemeta::hydra::http::Method::GET ||
          request.method() == sourcemeta::hydra::http::Method::HEAD);
 
@@ -48,7 +48,7 @@ auto serve_file(const std::filesystem::path &file_path,
     return;
   }
 
-  response.status(sourcemeta::hydra::http::Status::OK);
+  response.status(code);
   response.header("Content-Type", sourcemeta::hydra::mime_type(file_path));
   response.header_etag(etag.str());
   response.header_last_modified(last_modified);

--- a/test/e2e/httpserver/httpserver_test.cc
+++ b/test/e2e/httpserver/httpserver_test.cc
@@ -943,6 +943,31 @@ TEST(e2e_HTTP_Server, static_document_get) {
   EXPECT_EQ(result.str(), "{ \"foo\": \"bar\" }\n");
 }
 
+TEST(e2e_HTTP_Server, static_document_get_with_code_override) {
+  sourcemeta::hydra::http::ClientRequest request{
+      std::string{HTTPSERVER_BASE_URL()} + "/static-404/document.json"};
+  request.method(sourcemeta::hydra::http::Method::GET);
+  request.capture();
+  sourcemeta::hydra::http::ClientResponse response{request.send().get()};
+  EXPECT_EQ(response.status(), sourcemeta::hydra::http::Status::NOT_FOUND);
+  EXPECT_TRUE(response.header("content-length").has_value());
+  EXPECT_EQ(response.header("content-length").value(), "37");
+  EXPECT_TRUE(response.header("content-type").has_value());
+  EXPECT_EQ(response.header("content-type").value(), "application/json");
+  EXPECT_TRUE(response.header("last-modified").has_value());
+  EXPECT_TRUE(response.header("etag").has_value());
+  EXPECT_EQ(response.header("etag").value(),
+            "\"cef8a5c5d7fcfb9cf601bf3a146a47e7\"");
+
+  std::ostringstream result;
+  std::copy(
+      std::istreambuf_iterator<std::ostringstream::char_type>(response.body()),
+      std::istreambuf_iterator<std::ostringstream::char_type>(),
+      std::ostreambuf_iterator<std::ostringstream::char_type>(result));
+
+  EXPECT_EQ(result.str(), "{ \"foo\": \"bar\" }\n");
+}
+
 TEST(e2e_HTTP_Server, static_document_head) {
   sourcemeta::hydra::http::ClientRequest request{
       std::string{HTTPSERVER_BASE_URL()} + "/static/document.json"};

--- a/test/e2e/httpserver/stub.cc
+++ b/test/e2e/httpserver/stub.cc
@@ -198,6 +198,22 @@ static auto on_static(const sourcemeta::hydra::http::ServerLogger &,
   sourcemeta::hydra::http::serve_file(file_path, request, response);
 }
 
+static auto on_static_404(const sourcemeta::hydra::http::ServerLogger &,
+                          const sourcemeta::hydra::http::ServerRequest &request,
+                          sourcemeta::hydra::http::ServerResponse &response)
+    -> void {
+  const std::filesystem::path file_path{STATIC_PATH +
+                                        request.path().substr(11)};
+  if (!std::filesystem::exists(file_path)) {
+    response.status(sourcemeta::hydra::http::Status::NOT_FOUND);
+    response.end();
+    return;
+  }
+
+  sourcemeta::hydra::http::serve_file(
+      file_path, request, response, sourcemeta::hydra::http::Status::NOT_FOUND);
+}
+
 static auto on_error(std::exception_ptr error,
                      const sourcemeta::hydra::http::ServerLogger &,
                      const sourcemeta::hydra::http::ServerRequest &,
@@ -246,6 +262,8 @@ auto main(int argc, char *argv[]) -> int {
   server.route(sourcemeta::hydra::http::Method::POST, "/cache-me", on_cache_me);
   server.route(sourcemeta::hydra::http::Method::GET, "/etag-quoted",
                on_etag_quoted);
+  server.route(sourcemeta::hydra::http::Method::GET, "/static-404/*",
+               on_static_404);
   server.route(sourcemeta::hydra::http::Method::GET, "/static/*", on_static);
   server.route(sourcemeta::hydra::http::Method::HEAD, "/static/*", on_static);
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
