### PR TITLE
Follow re-directs by default in HTTP client

### DIFF
--- a/src/httpclient/request.cc
+++ b/src/httpclient/request.cc
@@ -87,8 +87,26 @@ auto ClientRequest::send(std::istream &body) -> std::future<ClientResponse> {
 }
 
 auto ClientRequest::send() -> std::future<ClientResponse> {
-  static std::istringstream empty_body;
-  return this->send(empty_body);
+  std::ostringstream output;
+  this->stream.on_data(
+      [&output](const Status, std::span<const std::uint8_t> buffer) noexcept {
+        std::copy(buffer.begin(), buffer.end(),
+                  std::ostream_iterator<char>(output));
+      });
+
+  std::map<std::string, std::string> headers;
+  this->stream.on_header([&headers, this](const Status, std::string_view key,
+                                          std::string_view value) noexcept {
+    std::string header{key};
+    if (this->capture_.contains(header) || this->capture_all_) {
+      headers.insert_or_assign(std::move(header), std::string{value});
+    }
+  });
+
+  std::promise<ClientResponse> response;
+  response.set_value(
+      {this->stream.send().get(), std::move(headers), std::move(output)});
+  return response.get_future();
 }
 
 } // namespace sourcemeta::hydra::http

--- a/test/e2e/httpclient/request_1_1_test.cc
+++ b/test/e2e/httpclient/request_1_1_test.cc
@@ -429,6 +429,16 @@ TEST(e2e_HTTP_Request_1_1, root_empty_istringstream) {
   EXPECT_EQ(body(response), "RECEIVED POST /");
 }
 
+TEST(e2e_HTTP_Request_1_1, GET_root_moved) {
+  sourcemeta::hydra::http::ClientRequest request{HTTPCLIENT_BASE_URL() +
+                                                 "/moved"};
+  request.method(sourcemeta::hydra::http::Method::GET);
+  sourcemeta::hydra::http::ClientResponse response{request.send().get()};
+  EXPECT_EQ(response.status(), sourcemeta::hydra::http::Status::OK);
+  EXPECT_FALSE(response.empty());
+  EXPECT_EQ(body(response), "RECEIVED GET /followed");
+}
+
 TEST(e2e_HTTP_Request_1_1, unsigned_long_header) {
   sourcemeta::hydra::http::ClientRequest request{HTTPCLIENT_BASE_URL()};
   request.method(sourcemeta::hydra::http::Method::GET);

--- a/test/e2e/httpclient/stub.js
+++ b/test/e2e/httpclient/stub.js
@@ -14,6 +14,13 @@ http.createServer((request, response) => {
     return;
   }
 
+  if (request.url === '/moved') {
+    response.statusCode = 301;
+    response.setHeader('Location', '/followed');
+    response.end();
+    return;
+  }
+
   for (const [key, value] of Object.entries(request.headers)) {
     response.setHeader(`X-${key}`, value);
   }


### PR DESCRIPTION
To easily test locally:

```sh
$ make up-httpclient-stub
$ SOURCEMETA_HYDRA_TEST_HTTPCLIENT_BASE_URL=http://localhost:9999 ./build/test/e2e/httpclient/sourcemeta_hydra_httpclient_e2e_unit
```

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
